### PR TITLE
Drop all explicit python2.7 support

### DIFF
--- a/bin/gwvet-vdf
+++ b/bin/gwvet-vdf
@@ -3,8 +3,6 @@
 """Analyse a veto definer file in full using the GWpy VET package
 """
 
-from __future__ import print_function
-
 import os
 import sys
 import re

--- a/gwvet/_version.py
+++ b/gwvet/_version.py
@@ -9,7 +9,6 @@
 # versioneer-0.16 (https://github.com/warner/python-versioneer)
 
 """Git implementation of _version.py."""
-from __future__ import print_function
 
 import errno
 import os

--- a/gwvet/core.py
+++ b/gwvet/core.py
@@ -19,10 +19,7 @@
 """Core evaluation methods for GWpy VET
 """
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 
 from gwpy.segments import DataQualityFlag
 

--- a/gwvet/etg.py
+++ b/gwvet/etg.py
@@ -19,8 +19,6 @@
 """ETG configurations
 """
 
-from six import string_types
-
 from gwsumm.utils import re_cchar
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -57,7 +55,7 @@ def get_etg_parameters(name, **kwargs):
     except KeyError:
         params = register_etg_parameters(canon)
     for key, val in params.items():
-        if isinstance(val, string_types):
+        if isinstance(val, str):
             params[key] = val.format(**kwargs)
     return params
 

--- a/gwvet/metric/__init__.py
+++ b/gwvet/metric/__init__.py
@@ -25,7 +25,6 @@ GWpy VET defines a custom `Metric` object, designed to wrap existing
 figure-of-merit functions into a standard format such that they can be
 applied conveniently to a set of segments and event triggers.
 """
-from __future__ import absolute_import
 
 from .core import (  # noqa: F401
     Metric,

--- a/gwvet/metric/core.py
+++ b/gwvet/metric/core.py
@@ -18,21 +18,12 @@
 
 """Core utilities and classes for common VET metrics
 """
-from __future__ import absolute_import
 
+import builtins
 import imp
 import inspect
 import re
-
-try:
-    from importlib import import_module
-except ImportError:
-    import_module = __import__
-
-try:
-    import __builtin__ as builtin
-except ImportError:
-    import builtins as builtin
+from importlib import import_module
 
 from astropy.units import (Quantity, Unit, dimensionless_unscaled)
 
@@ -238,7 +229,7 @@ class Metric(object):
             modulename, methodname = methodstr.rsplit('.', 1)
         except ValueError:
             methodname = methodstr
-            method = getattr(builtin, methodname)
+            method = getattr(builtins, methodname)
         else:
             module = import_module(modulename)
             method = getattr(module, methodname)

--- a/gwvet/metric/metrics.py
+++ b/gwvet/metric/metrics.py
@@ -19,8 +19,6 @@
 """This module defines a number of standard `metrics <Metric>`.
 """
 
-from __future__ import division
-
 import decorator
 import operator
 

--- a/gwvet/metric/registry.py
+++ b/gwvet/metric/registry.py
@@ -28,14 +28,14 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 _METRICS = {}
 
-REGEX_METRIC_FACTORY = re.compile(  # noqa W605
-    '(?P<metric>(.*))\|(\s+)?'  # match metric name,
-    '(?P<column>[\w\s]+)(\s+)?'  # match column name
-    '(?P<operator>[<>=!]+)(\s+)?'  # match operator
-    '(?P<value>(.*))\Z'  # match value (arbitrary text)
+REGEX_METRIC_FACTORY = re.compile(
+    r'(?P<metric>(.*))\|(\s+)?'  # match metric name,
+    r'(?P<column>[\w\s]+)(\s+)?'  # match column name
+    r'(?P<operator>[<>=!]+)(\s+)?'  # match operator
+    r'(?P<value>(.*))\Z'  # match value (arbitrary text)
 )
-REGEX_LOUDEST_EVENT_FACTORY = re.compile(  # noqa W605
-    'loudest event by (?P<column>[\w\s]+)', re.I)
+REGEX_LOUDEST_EVENT_FACTORY = re.compile(
+    r'loudest event by (?P<column>[\w\s]+)', re.I)
 
 
 def register_metric(metric, name=None, force=False):

--- a/gwvet/tabs.py
+++ b/gwvet/tabs.py
@@ -20,10 +20,7 @@
 """
 
 import os
-try:
-    from configparser import NoOptionError
-except ImportError:  # python < 3
-    from ConfigParser import NoOptionError
+from configparser import NoOptionError
 
 from astropy.units import Unit
 from MarkupPy import markup

--- a/gwvet/triggers.py
+++ b/gwvet/triggers.py
@@ -29,7 +29,7 @@ from gwsumm.triggers import (get_triggers, get_times)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-re_meta = re.compile('(\||:|\&)')  # noqa: W605
+re_meta = re.compile(r'(\||:|\&)')
 
 
 def veto(table, flag, tag='', channel='unknown-channel', etg='unknown-etg'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ decorator
 dqsegdb
 gwdetchar>=1.0.0
 gwpy>=1.0.0
-gwsumm>=1.0.0
+gwsumm>=1.0.1
 gwtrigfind
 lscsoft-glue>=1.60.0
 MarkupPy

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_requires = [
     'dqsegdb',
     'gwdetchar>=1.0.0',
     'gwpy>=1.0.0',
-    'gwsumm>=1.0.0',
+    'gwsumm>=1.0.1',
     'gwtrigfind',
     'lscsoft-glue>=1.60.0',
     'MarkupPy',

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,6 @@
 """Setup the GWpy VET (`gwvet`) package
 """
 
-from __future__ import print_function
-
-import sys
-if sys.version < '2.6':
-    raise ImportError("Python versions older than 2.6 are not supported.")
-
 import glob
 import os.path
 
@@ -34,9 +28,9 @@ from setuptools import (setup, find_packages)
 # set basic metadata
 PACKAGENAME = 'gwvet'
 DISTNAME = 'gwvet'
-AUTHOR = 'Duncan Macleod'
-AUTHOR_EMAIL = 'duncan.macleod@ligo.org'
-LICENSE = 'GPLv3'
+AUTHOR = 'Duncan Macleod, Alex Urban'
+AUTHOR_EMAIL = 'alexander.urban@ligo.org'
+LICENSE = 'GPL-3.0-or-later'
 
 cmdclass = {}
 
@@ -98,6 +92,12 @@ setup(name=DISTNAME,
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,
+      url='https://github.com/gwpy/vet',
+      project_urls={
+          "Bug Tracker": "https://github.com/gwpy/vet/issues",
+          "Discussion Forum": "https://gwdetchar.slack.com",
+          "Source Code": "https://github.com/gwpy/vet",
+      },
       packages=packagenames,
       include_package_data=True,
       cmdclass=cmdclass,
@@ -110,15 +110,16 @@ setup(name=DISTNAME,
           'Programming Language :: Python',
           'Development Status :: 3 - Alpha',
           'Intended Audience :: Science/Research',
-          'Intended Audience :: End Users/Desktop',
-          'Intended Audience :: Developers',
+          ('License :: OSI Approved :: '
+           'GNU General Public License v3 or later (GPLv3+)'),
           'Natural Language :: English',
-          'Topic :: Scientific/Engineering',
+          'Operating System :: OS Independent',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
           'Topic :: Scientific/Engineering :: Astronomy',
           'Topic :: Scientific/Engineering :: Physics',
-          'Operating System :: POSIX',
-          'Operating System :: Unix',
-          'Operating System :: MacOS',
           'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
       ],
       )


### PR DESCRIPTION
This PR drops all explicit support for python-2.7, and updates some metadata information in anticipation of a 0.1.0 release. It also bumps the GWSumm requirement to 1.0.1, which includes crucial bugfixes for `gps` mode.

Example output is available [**here**](https://ldas-jobs.ligo-wa.caltech.edu/~aurban/for_brennan/1244307456-1253923218/wind_check/) (requires `LIGO.ORG` credentials).

cc @duncanmmacleod 