### PR TITLE
Added glitchgram plotting args

### DIFF
--- a/gwvet/etg.py
+++ b/gwvet/etg.py
@@ -86,7 +86,7 @@ def get_canonical_etg_name(name):
 
 register_etg_parameters('omicron', **{
     'time': 'peak',
-    'ylim': [10,5000],
+    'ylim': [10, 5000],
 })
 register_etg_parameters('kleinewelle', time='peak', frequency='central_freq')
 register_etg_parameters('excesspower', time='peak', frequency='central_freq')

--- a/gwvet/etg.py
+++ b/gwvet/etg.py
@@ -84,7 +84,10 @@ def get_canonical_etg_name(name):
 # -----------------------------------------------------------------------------
 # register well known ETGs
 
-register_etg_parameters('omicron', time='peak')
+register_etg_parameters('omicron', **{
+    'time': 'peak',
+    'ylim': [10,5000],
+})
 register_etg_parameters('kleinewelle', time='peak', frequency='central_freq')
 register_etg_parameters('excesspower', time='peak', frequency='central_freq')
 register_etg_parameters('cwb', **{
@@ -108,6 +111,7 @@ register_etg_parameters('ahope', **{
 register_etg_parameters('pycbc', **{
     'time': 'end_time',
     'frequency': 'template_duration',
+    'ylim': [0.1, 130],
     'det': 'new_snr',
     'det-limits': [6, 10],
     'det-scale': 'linear',

--- a/gwvet/tabs.py
+++ b/gwvet/tabs.py
@@ -194,7 +194,7 @@ class FlagTab(ParentTab):
                     kwargs['intersection'] = False
         # get glitchgram plotting arguments
         kwargs['glitchgramargs'] = {key.split('glitchgram-')[1]: val for
-                                    key, val in config.items(section) if
+                                    (key, val) in config.items(section) if
                                     key.startswith('glitchgram-')}
         for key in kwargs['glitchgramargs']:
             val = kwargs['glitchgramargs'][key]

--- a/gwvet/tabs.py
+++ b/gwvet/tabs.py
@@ -254,7 +254,7 @@ class FlagTab(ParentTab):
                     'ylabel': params.get(
                         'frequency-label',
                         get_column_label(params['frequency'])),
-                    'ylim': params.get('ylim', [10,5000]),
+                    'ylim': params.get('ylim', [10, 5000]),
                     'edgecolor': 'none',
                     'legend-scatterpoints': 1,
                     'legend-borderaxespad': 0,

--- a/gwvet/tabs.py
+++ b/gwvet/tabs.py
@@ -103,6 +103,7 @@ class FlagTab(ParentTab):
                  segmentfile=None,
                  minseglength=0,
                  padding=(0, 0),
+                 glitchgramargs=None,
                  plotdir=os.curdir, states=list([ALLSTATE]), **kwargs):
         if len(flags) == 0:
             flags = [name]
@@ -121,6 +122,7 @@ class FlagTab(ParentTab):
         self.filterstr = None
         self.intersection = intersection
         self.padding = format_padding(self.flags, padding)
+        self.glitchgramargs = glitchgramargs
         if intersection:
             self.metaflag = '&'.join(list(map(str, self.flags)))
         else:
@@ -190,6 +192,14 @@ class FlagTab(ParentTab):
                                      combine)
                 else:
                     kwargs['intersection'] = False
+        # get glitchgram plotting arguments
+        kwargs['glitchgramargs'] = {key.split('glitchgram-')[1]: val for
+                                    key, val in config.items(section) if
+                                    key.startswith('glitchgram-')}
+        for key in kwargs['glitchgramargs']:
+            val = kwargs['glitchgramargs'][key]
+            if key in ['xlim', 'ylim'] and isinstance(val, str):
+                kwargs['glitchgramargs'][key] = eval(val)
         # make tab and return
         new = super(ParentTab, cls).from_ini(config, section, **kwargs)
         # get trigger filter
@@ -244,6 +254,7 @@ class FlagTab(ParentTab):
                     'ylabel': params.get(
                         'frequency-label',
                         get_column_label(params['frequency'])),
+                    'ylim': params.get('ylim', [10,5000]),
                     'edgecolor': 'none',
                     'legend-scatterpoints': 1,
                     'legend-borderaxespad': 0,
@@ -251,6 +262,7 @@ class FlagTab(ParentTab):
                     'legend-loc': 'upper left',
                     'legend-frameon': False,
                 }
+                glitchgramargs.update(self.glitchgramargs)
                 # plot before/after glitchgram
                 self.plots.append(get_plot('triggers')(
                     [after, vetoed], self.start, self.end, state=state,


### PR DESCRIPTION
Adds default glitchgram y-limits for Omicron and PyCBC and allows for further glitchgram customization via config file arguments.

Any arguments passed to either `[DEFAULT]` or an individual tab as `glitchgram-*` will be interpreted as plotting kwargs for all glitchgrams in the relevant tab.

Example using original code: https://ldas-jobs.ligo-la.caltech.edu/~tjmassin/detchar/O3/test/VET/original/1268359600-1268360600/rf45_1p5/

Example with new defaults `ylim = [10, 5000]`: https://ldas-jobs.ligo-la.caltech.edu/~tjmassin/detchar/O3/test/VET/new_default/1268359600-1268360600/rf45_1p5/

Example with all tabs set to have `ylim = [10, 2048]` by invoking `glitchgram-ylim = 10,2048` in `[DEFAULT]`: https://ldas-jobs.ligo-la.caltech.edu/~tjmassin/detchar/O3/test/VET/custom-ylim/1268359600-1268360600/rf45_1p75/

Example with only one tab set to have `ylim = [10, 2048]` by invoking `glitchgram-ylim = 10,2048` in an individual tab section: https://ldas-jobs.ligo-la.caltech.edu/~tjmassin/detchar/O3/test/VET/custom-ylim-single-page/1268359600-1268360600/rf45_1p5/