### PR TITLE
Update omicron column in the hdf5 format

### DIFF
--- a/gwvet/etg.py
+++ b/gwvet/etg.py
@@ -85,7 +85,9 @@ def get_canonical_etg_name(name):
 # register well known ETGs
 
 register_etg_parameters('omicron', **{
-    'time': 'peak',
+    # omicron hdf5 columns
+    'time': 'time',
+    'frequency': 'frequency', 
     'ylim': [10, 5000],
 })
 register_etg_parameters('kleinewelle', time='peak', frequency='central_freq')


### PR DESCRIPTION
This PR updates the omicron column names to be compatible with the HDF5 format. This is needed to make VET compatible with the new version of GWSumm, which [uses HDF5 format as default](https://github.com/gwpy/gwsumm/pull/397). 

Omicron will soon drop support for the XML format, [see here](https://github.com/gwpy/pyomicron/issues/153).